### PR TITLE
Reset overlays on new searches

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,6 +98,11 @@ function runSearch(lat, lon) {
   updateMarkersAndTable(result, lat, lon);
   drawChart(result, lat, lon);
   map.fitBounds(circle.getBounds());
+
+  // Ensure visual overlay matches new results
+  if (typeof updateVisualSelectionState === 'function') {
+    updateVisualSelectionState();
+  }
 }
 // --- END BLOCK 2 ---
 
@@ -227,6 +232,11 @@ const zipListHTML = list
       }
     });
   });
+
+  // Reset overlay markers after rendering new results
+  if (typeof updateVisualSelectionState === 'function') {
+    updateVisualSelectionState();
+  }
 }
 // --- END BLOCK 3 ---
 


### PR DESCRIPTION
## Summary
- update markers and overlay visuals after running a search
- refresh overlays when the list view is regenerated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd29821608322bf7e69bb9421eefd