### PR TITLE
Fix early return for zip input

### DIFF
--- a/app.js
+++ b/app.js
@@ -299,6 +299,7 @@ zipInput.addEventListener('paste', () => {
   setTimeout(() => document.getElementById('searchBtn').click(), 50);
 });
 zipInput.addEventListener('input', () => {
+  if (!plzDataLoaded) return;
   const val = zipInput.value.trim();
   if (val.length === 5) {
     const found = plzData.find(p => p.plz === val);


### PR DESCRIPTION
## Summary
- guard ZIP input handler in `app.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686698da50708322b6124a78197fd141